### PR TITLE
cwt config improvement

### DIFF
--- a/config/common/megastructures.cwt
+++ b/config/common/megastructures.cwt
@@ -192,6 +192,6 @@ megastructure = {
 	## replace_scopes = { this = system root = system from = country fromfrom = megastructure }
 	dismantle_possible = single_alias_right[trigger_clause]
 	## cardinality = 0..1
-	## replace_scopes = { this = system root = system from = country fromfrom = megastructure }
+	## replace_scopes = { this = system root = system from = country }
 	on_dismantle_complete = single_alias_right[effect_clause]
 }

--- a/config/gfx/sprite_configurations.cwt
+++ b/config/gfx/sprite_configurations.cwt
@@ -1,0 +1,20 @@
+
+types = {
+	type[sprite_configurations] = {
+		path = "game/gfx/portraits/sprite_configurations"
+		path_extension = .txt
+		path_strict = yes
+		skip_root_key = portraits
+	}
+}
+
+sprite_configurations = {
+	## cardinality = 0..1
+	trigger = single_alias_right[trigger_clause]
+
+	## file_extensions = { .dds .png .tga }
+	masking_texture = filepath
+
+	## file_extensions = { .shader }
+	effectFile = filepath
+}

--- a/config/interface/sprites.cwt
+++ b/config/interface/sprites.cwt
@@ -75,6 +75,10 @@ sprite = {
 		## cardinality = 0..1
 		type = enum[sprite_type]
 		## cardinality = 0..1
+		alternate_configurations = {
+			<sprite_configurations>
+		}
+		## cardinality = 0..1
 		character = bool
 		## cardinality = 0..1
 		close_up = bool


### PR DESCRIPTION
1. 巨构的`on_dismantle_complete`没有`fromfrom`域 
    参见`common\megastructures\99_README_MEGASTRUCTURES.txt`

3. 添加`sprite_configurations`的相关规则